### PR TITLE
Avoid repeated initialization of the shim module

### DIFF
--- a/rpm/__init__.py
+++ b/rpm/__init__.py
@@ -88,10 +88,13 @@ def initialize() -> None:
         except ShimAlreadyInitializingError:
             continue
         except Exception as e:
-            logger.error(f"Exception: {e}")
+            logger.debug(f"Exception: {type(e)}: {e}")
             continue
     else:
-        raise ImportError("Failed to import system RPM module")
+        raise ImportError(
+            "Failed to import system RPM module. "
+            "Make sure RPM Python bindings are installed on your system."
+        )
 
 
 # avoid repeated initialization of the shim module

--- a/rpm/__init__.py
+++ b/rpm/__init__.py
@@ -20,6 +20,10 @@ MODULE_NAME = "rpm"
 logger = logging.getLogger(PROJECT_NAME)
 
 
+class ShimAlreadyInitializingError(Exception):
+    pass
+
+
 def get_system_sitepackages() -> List[str]:
     """
     Gets a list of sitepackages directories of system Python interpreter(s).
@@ -71,7 +75,7 @@ def try_path(path: str) -> bool:
     return False
 
 
-def init_module() -> None:
+def initialize() -> None:
     """
     Initializes the shim. Tries to load system RPM module and replace itself with it.
     """
@@ -81,6 +85,8 @@ def init_module() -> None:
             if try_path(path):
                 logger.debug("Import successfull")
                 return
+        except ShimAlreadyInitializingError:
+            continue
         except Exception as e:
             logger.error(f"Exception: {e}")
             continue
@@ -88,4 +94,11 @@ def init_module() -> None:
         raise ImportError("Failed to import system RPM module")
 
 
-init_module()
+# avoid repeated initialization of the shim module
+try:
+    _shim_module_initializing_
+except NameError:
+    _shim_module_initializing_: bool = True
+    initialize()
+else:
+    raise ShimAlreadyInitializingError


### PR DESCRIPTION
When the shim module tries to reload itself, it repeats the loop of trying all the sitepackages directories, and because `importlib.reload()` is noop when called recursively, it ends up raising `ImportError` that is visible to the user.
Even though execution returns to the original loop and the system RPM module is loaded successfully, the error message produced is very confusing.

Improve that by avoiding repeated initialization of the shim module. Also make sure that `importlib.reload()`, when loading the shim module for the second time, throws a specific exception that doesn't trigger any log message, to make things even less confusing.