### PR TITLE
Consider also majorver.minorver variant of Python interpreter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,9 @@ jobs:
             install_deps_cmd: dnf -y install git-core python3-pip python3-rpm
           - base_image: centos:stream9
             install_deps_cmd: dnf -y install git-core python3-pip python3-rpm
-          - base_image: centos:stream8
+          - base_image: registry.access.redhat.com/ubi9:latest
+            install_deps_cmd: dnf -y install git-core python3-pip python3-rpm && python3 -m pip install -U requests
+          - base_image: ubi8:latest
             install_deps_cmd: dnf -y install git-core python3-pip python3-rpm
           - base_image: opensuse/leap:latest
             install_deps_cmd: zypper -n install git-core python3-pip python3-rpm

--- a/rpm/__init__.py
+++ b/rpm/__init__.py
@@ -41,9 +41,13 @@ def get_system_sitepackages() -> List[str]:
         output = subprocess.check_output(command)
         return json.loads(output.decode())
 
-    majorver, *_ = platform.python_version_tuple()
+    majorver, minorver, _ = platform.python_version_tuple()
     # try platform-python first (it could be the only interpreter present on the system)
-    interpreters = ["/usr/libexec/platform-python", f"/usr/bin/python{majorver}"]
+    interpreters = [
+        "/usr/libexec/platform-python",
+        f"/usr/bin/python{majorver}",
+        f"/usr/bin/python{majorver}.{minorver}",
+    ]
     result = []
     for interpreter in interpreters:
         if not Path(interpreter).is_file():

--- a/tests/Containerfile
+++ b/tests/Containerfile
@@ -9,7 +9,7 @@ COPY . .
 ARG INSTALL_DEPS_CMD
 RUN sh -c "${INSTALL_DEPS_CMD}"
 
-RUN python3 -m pip install tox build
+RUN python3 -m pip install tox build || python3 -m pip install --break-system-packages tox build
 
 WORKDIR /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,310,311}
+envlist = py{36,37,38,39,310,311,312,313}
 skip_missing_interpreters = true
 isolated_build = true
 


### PR DESCRIPTION
Fixes #9.
Fixes #10.

RELEASE NOTES BEGIN

rpm-shim now considers also system Python interpreter called `python{majorver}.{minorver}` when gathering the list of paths to try importing the system `rpm` module from. Peviously only `python{majorver}` and `platform-python` were considered.

RELEASE NOTES END
