### PR TITLE
Skip interpreters with different version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
             install_deps_cmd: dnf -y install git-core python{3,3.11}-pip python3-rpm && python3 -m pip install -U requests && python3.11 -m pip install -U requests
           - base_image: ubi8:latest
             install_deps_cmd: dnf -y install git-core python3-pip python3-rpm
-          - base_image: opensuse/leap:latest
+          - base_image: registry.opensuse.org/opensuse/leap:latest
             install_deps_cmd: zypper -n install git-core python3-pip python3-rpm
           - base_image: registry.suse.com/bci/python:3.11
             install_deps_cmd: zypper -n install python311-rpm python3-rpm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,8 @@ jobs:
             install_deps_cmd: dnf -y install git-core python3-pip python3-rpm
           - base_image: opensuse/leap:latest
             install_deps_cmd: zypper -n install git-core python3-pip python3-rpm
+          - base_image: registry.suse.com/bci/python:3.11
+            install_deps_cmd: zypper -n install python311-rpm python3-rpm
           - base_image: ubuntu:latest
             install_deps_cmd: apt-get -y update && apt-get -y install git python3-pip python3-rpm
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.2.0
     hooks:
       - id: flake8
         args:
@@ -54,4 +54,4 @@ repos:
       - id: check-rebase
         args:
           - https://github.com/packit/rpm-shim.git
-        stages: [manual, push]
+        stages: [manual, pre-push]

--- a/rpm/__init__.py
+++ b/rpm/__init__.py
@@ -64,8 +64,8 @@ def get_system_sitepackages_and_suffixes() -> List[Dict[str, List[str]]]:
     # try platform-python first (it could be the only interpreter present on the system)
     interpreters = [
         "/usr/libexec/platform-python",
-        f"/usr/bin/python{majorver}",
         f"/usr/bin/python{majorver}.{minorver}",
+        f"/usr/bin/python{majorver}",
     ]
     result = []
     for interpreter in interpreters:

--- a/tests/import.py
+++ b/tests/import.py
@@ -12,6 +12,10 @@ def test():
 
     # sanity check
     print("RPM conf dir:", rpm.expandMacro("%getconfdir"))
+    # the spec class should be present, but loading it fails if there is an ABI
+    # mismatch between the current interpreter and the site packages from which
+    # we loaded the module
+    rpm.spec
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [-] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

Fixes #21

<!-- release notes footer -->

RELEASE NOTES BEGIN

`rpm-shim` now prefers the current interpreter for searching for the `rpm` module

RELEASE NOTES END
