### PR TITLE
Remove setuptools_scm_git_archive for compatibility setuptools>=82

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     "setuptools>=45",
     "setuptools_scm[toml]",
-    "setuptools_scm_git_archive",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
When building from source :

    pip install --no-binary :all: .

fails because `setuptools_scm_git_archive` depends on `pkg_resources`,
 which was removed in setuptools 82.
Reference: https://setuptools.pypa.io/en/stable/history.html#v82-0-0

Due to this our hermetic builds failed in the RH Konflux CI as in Konflux packages are built from source tar in the offline environment, rather then directly downloading `whl` packages

I tested locally using in a ubi container and I can see that the package is being built after removing entry for `setuptools_scm_git_archive`.
~~~
[root@9d0ea0608c60 app]# pip install . --no-binary :all:
Processing ./.
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: rpm
  Building wheel for rpm (pyproject.toml) ... done
  Created wheel for rpm: filename=rpm-0.4.0.post3+g6efb0eb3e-py3-none-any.whl size=6207 sha256=dbbffe21a6007f703b5c77db3eb6cdfa46a62f3659919a61eead8a94586e2d03
  Stored in directory: /tmp/pip-ephem-wheel-cache-flqq2zqh/wheels/57/0f/98/bb57b2b57b95807699b822a35c022f139d38a02c27922f27ce
Successfully built rpm
Installing collected packages: rpm
Successfully installed rpm-0.4.0.post3+g6efb0eb3e
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
[root@9d0ea0608c60 app]# 
~~~

Also able to test this in ubi9 container using the command arguments referenced in `.github/workflows/tests.yml`
~~~
→ make test BASE_IMAGE="registry.access.redhat.com/ubi9:latest" INSTALL_DEPS_CMD=" dnf -y install git-core python{3,3.11}-pip python3-rpm && python3 -m pip install -U requests && python3.11 -m pip install -U requests"
[...]
Successfully built rpm-0.4.0.post3+g6efb0eb3e-py3-none-any.whl                                                                                                                                                     
Processing /rpm-shim/dist/rpm-0.4.0.post3+g6efb0eb3e-py3-none-any.whl                                                                                                                                              
Installing collected packages: rpm                                                                                                                                                                                 
Successfully installed rpm-0.4.0.post3+g6efb0eb3e                                                                                                                                                                  
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/war
nings/venv                                                                                                                                                                                                         
DEBUG:rpm-shim:Collected sitepackages and extension suffixes for /usr/libexec/platform-python:                                                                                                                     
{'sitepackages': ['/usr/local/lib64/python3.9/site-packages',                                                                                                                                                      
                  '/usr/local/lib/python3.9/site-packages',                                                                                                                                                        
                  '/usr/lib64/python3.9/site-packages',                                                                                                                                                            
                  '/usr/lib/python3.9/site-packages'],                                                                                                                                                             
 'suffixes': ['.cpython-39-x86_64-linux-gnu.so', '.abi3.so', '.so']}                                                                                                                                               
DEBUG:rpm-shim:Collected sitepackages and extension suffixes for /usr/bin/python3.9:                                                                                                                               
{'sitepackages': ['/usr/local/lib64/python3.9/site-packages',                                                                                                                                                      
                  '/usr/local/lib/python3.9/site-packages',                                                                                                                                                        
                  '/usr/lib64/python3.9/site-packages',
                  '/usr/lib/python3.9/site-packages'],
 'suffixes': ['.cpython-39-x86_64-linux-gnu.so', '.abi3.so', '.so']}
DEBUG:rpm-shim:Collected sitepackages and extension suffixes for /usr/bin/python3:
{'sitepackages': ['/usr/local/lib64/python3.9/site-packages',
                  '/usr/local/lib/python3.9/site-packages',
                  '/usr/lib64/python3.9/site-packages',                                                  
                  '/usr/lib/python3.9/site-packages'],                                                   
 'suffixes': ['.cpython-39-x86_64-linux-gnu.so', '.abi3.so', '.so']}                                     
DEBUG:rpm-shim:Trying /usr/local/lib64/python3.9/site-packages
DEBUG:rpm-shim:Trying /usr/local/lib/python3.9/site-packages
DEBUG:rpm-shim:Trying /usr/lib64/python3.9/site-packages
DEBUG:rpm-shim:Reloaded rpm
DEBUG:rpm-shim:Import successfull
RPM conf dir: /usr/lib/rpm
No broken requirements found.

~~~

Fixes #25


<!-- TODO list -->

I have not changed any code or tests and only changed `pyproject.toml` file. Please do let me know if any change is needed at other files mentioned in TODO below.

TODO:

- [-] Write new tests or update the old ones to cover new functionality.
- [-] Update doc-strings where appropriate.
- [-] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->


<!-- release notes footer -->

RELEASE NOTES BEGIN

Removed `setuptools_scm_git_archive` as a dependency for `rpm-shim` since building from source using `--no-binary` fails because `setuptools_scm_git_archive` requires `pkg_resource`  as dependency but it was removed in setuptools 82.
Reference: https://setuptools.pypa.io/en/stable/history.html#v82-0-0

RELEASE NOTES END
